### PR TITLE
Disable auto release publisihing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: cloudposse/github-action-auto-release@v1
         with:
           prerelease: false
-          publish: true
+          publish: false
           config-name: auto-release.yml


### PR DESCRIPTION
## what

- Disable auto release publisihing

## why

- Auto-release publish does not trigger release workflow